### PR TITLE
Fix target language in translation file template

### DIFF
--- a/translations/lxqt-openssh-askpass.ts
+++ b/translations/lxqt-openssh-askpass.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="en_US">
+<TS version="2.1">
 <context>
     <name>MainWindow</name>
     <message>


### PR DESCRIPTION
The translation file template was configured for a target language. This prevented Linguist from showing the selection dialog when the file was opened after copying it to a language-specific version. Not explicitly querying the language then could have led translators to not setting a target language and just keep the default which would have been wrong.

Thanks!
